### PR TITLE
Removed the line 17 `touch __init__.py`

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ git clone https://github.com/thmoa/videoavatars.git videoavatars
 cd videoavatars/vendor
 mkdir smpl
 cd smpl
-touch __init__.py
 ln -s <path to smpl folder>/models .
 ln -s <path to smpl folder>/smpl_webuser/*.py .
 cd ..


### PR DESCRIPTION
The current version of smpl_webuser comes with an __init__.py file and hence the soft link command was giving an error message.